### PR TITLE
Add ISR to content, category and tag pages

### DIFF
--- a/pages/categories/[slug].js
+++ b/pages/categories/[slug].js
@@ -33,6 +33,7 @@ export async function getStaticProps({ params }) {
     props: {
       category: category,
     },
+    revalidate: 300,
   };
 }
 

--- a/pages/categories/index.js
+++ b/pages/categories/index.js
@@ -18,5 +18,6 @@ export async function getStaticProps() {
     props: {
       categories: categories,
     },
+    revalidate: 300,
   };
 }

--- a/pages/content/[slug].js
+++ b/pages/content/[slug].js
@@ -213,6 +213,7 @@ export async function getStaticProps({ params }) {
         ...post,
       },
     },
+    revalidate: 60,
   };
 }
 

--- a/pages/content/index.js
+++ b/pages/content/index.js
@@ -23,5 +23,6 @@ export async function getStaticProps() {
     props: {
       posts: data.posts,
     },
+    revalidate: 300,
   };
 }

--- a/pages/series/[slug].js
+++ b/pages/series/[slug].js
@@ -31,6 +31,7 @@ export async function getStaticProps({ params }) {
     props: {
       series: series,
     },
+    revalidate: 300,
   };
 }
 

--- a/pages/tags/[slug].js
+++ b/pages/tags/[slug].js
@@ -37,6 +37,7 @@ export async function getStaticProps({ params }) {
     props: {
       tag: tag,
     },
+    revalidate: 300,
   };
 }
 

--- a/pages/tags/index.js
+++ b/pages/tags/index.js
@@ -20,5 +20,6 @@ export async function getStaticProps() {
     props: {
       tags: tags,
     },
+    revalidate: 300,
   };
 }


### PR DESCRIPTION
I have currently set the `revalidate` time to 300 seconds for list pages and 60 seconds for content pages. Can update this if needed.